### PR TITLE
The access directive is not open enough.

### DIFF
--- a/Sources/Strategy.swift
+++ b/Sources/Strategy.swift
@@ -18,7 +18,7 @@ open class Strategy {
 		private(set) var target: Evocation.RepositoryType
 		private(set) var fallback: Evocation.RepositoryType?
 
-		init(target: Evocation.RepositoryType = .remote, fallback: Evocation.RepositoryType? = nil, synchronize: Bool = true) throws {
+		public init(target: Evocation.RepositoryType = .remote, fallback: Evocation.RepositoryType? = nil, synchronize: Bool = true) throws {
 			self.target = target
 			self.fallback = fallback
 			self.synchronize = synchronize


### PR DESCRIPTION
[`Rule` Constructor is not able to be called]

**Reproduction Steps:**

1. Follow the example in README
2. `let localFirst  = Strategy.Rule(target: .local, fallback: .remote, synchronize: true)`
3. Error

**Screenshots and GIFs**
<img width="698" alt="screen shot 2017-03-31 at 10 59 17 pm" src="https://cloud.githubusercontent.com/assets/397660/24553608/b8308fbe-1665-11e7-9e71-aaa58b840630.png">

**OS and version:** [OSX 10.12.4, Xcode 8.3]

* Problem can be reliably reproduced, doesn't happen randomly: [Yes]
* Problem happens with all files and projects, not only some files or projects: [Yes]
